### PR TITLE
Bug branch prefix formatter + other fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,18 @@ Gitprefix is a Git `prepare-commit-msg` hook for formatting Git commit messages.
    - `initial commit`: 🎉
    - `responsive`: 📱
    - `accessibility`: ♿️
-   
+
 ## Usage
+
+### Prerequisites
+
+You need to have a git template directory set up. You can do this by creating an
+empty directory and adding this config to your `~/.gitconfig`:
+
+```ini
+[init]
+    templatedir = ~/path/to/your/git-template
+```
 
 ### Installation
 
@@ -34,7 +44,7 @@ npx gitprefix init
 
 ### Updating
 
-If the package is ever updated you can run the following command to pull down the new formatter and overwrite the existing file: 
+If the package is ever updated you can run the following command to pull down the new formatter and overwrite the existing file:
 
 ```sh
 npx gitprefix install --overwrite

--- a/commands/install.js
+++ b/commands/install.js
@@ -1,6 +1,7 @@
 const program = require('commander');
 const fs = require('fs-extra');
 const ini = require('ini');
+const path = require('path');
 const { resolveHome, logger } = require('../utils');
 const { name } = require('../package.json');
 
@@ -36,7 +37,8 @@ program
             process.exit();
         }
 
-        const formatterStub = fs.readFileSync('./stubs/formatter.js', 'utf-8');
+        const formatterPath = path.resolve(__dirname, '../stubs/formatter.js');
+        const formatterStub = fs.readFileSync(formatterPath, 'utf-8');
 
         fs.ensureDirSync(hooksDir);
         // Create the hook

--- a/stubs/formatter.js
+++ b/stubs/formatter.js
@@ -15,7 +15,14 @@ const EMOJI_REPLACEMENTS = {
     'accessibility': '♿️',
 };
 
-const BRANCH_REPLACEMENTS = ['ref: refs/heads/', '\n', 'task/', 'epic/', 'bug/'];
+const BRANCH_REPLACEMENTS = [
+    'ref: refs/heads/',
+    '\n',
+    'task/',
+    'epic/',
+    'bug/',
+    'hotfix/',
+];
 
 (async function updateCommitMessage() {
     let message = readFileSync(process.argv[2], 'utf8').trim();

--- a/stubs/formatter.js
+++ b/stubs/formatter.js
@@ -15,7 +15,7 @@ const EMOJI_REPLACEMENTS = {
     'accessibility': '♿️',
 };
 
-const BRANCH_REPLACEMENTS = ['ref: refs/heads/', '\n', 'task/', 'epic/'];
+const BRANCH_REPLACEMENTS = ['ref: refs/heads/', '\n', 'task/', 'epic/', 'bug/'];
 
 (async function updateCommitMessage() {
     let message = readFileSync(process.argv[2], 'utf8').trim();


### PR DESCRIPTION
- Adds `bug/` and `hotfix/` to the list of branch commit formatters
- Adds a prerequisite to the README
- Fixes the formatter stub file not being found when trying to install